### PR TITLE
Update link to Git for Ages 4 and Up video

### DIFF
--- a/content/sections/git-makes-more-sense-when-you-understand-x/example-2-git-for-ages-4-and-up.txt
+++ b/content/sections/git-makes-more-sense-when-you-understand-x/example-2-git-for-ages-4-and-up.txt
@@ -7,7 +7,7 @@ filter:
   - markdown
 ---
 
-In [Git for Ages 4 And Up](http://2010.osdc.com.au/proposal/196/git-ages-4-and) (OSDC, 2010), Michael Schwern uses Tinker Toys to teach the audience how Git works.
+In [Git for Ages 4 And Up](https://www.youtube.com/watch?v=1ffBJ4sVUb4) (YouTube, 2013), Michael Schwern uses Tinker Toys to teach the audience how Git works.
 
 It's a brilliant talk by a brilliant developer, and if you have some time to watch the video, I highly recommend it.  But check out the very first sentence in the session description *(emphasis added)*:
 


### PR DESCRIPTION
Replace external link to Michael Schwern's talk on git.
The video no longer exists at previous OSDC link.
New link directs to video of the talk on YouTube.
