### PR TITLE
#15 Fix broken link to Confreaks talk

### DIFF
--- a/source/sections/about-this-site/why-this-site.html.erb
+++ b/source/sections/about-this-site/why-this-site.html.erb
@@ -11,6 +11,6 @@ layout: section
 
 <p>This began life as a "Lunch and Learn" presentation to my coworkers.  Based on the positive feedback I got from that, I then gave the talk again at Portland BarCamp 2011 and Cascadia RubyConf 2011.</p>
 
-<p><em>(There's video of the Cascadia RubyConf talk on <a href="http://confreaks.net/videos/612-cascadiaruby2011-think-like-a-git">Confreaks</a>, but it's not very good&mdash;it was my first conference talk, and I delivered it with literally three minutes' warning.)</em></p>
+<p><em>(There's video of the Cascadia RubyConf talk on <a href="https://youtu.be/ZS_b3P8cknQ">Confreaks</a>, but it's not very good&mdash;it was my first conference talk, and I delivered it with literally three minutes' warning.)</em></p>
 
 <p>Based on encouraging feedback from both of those talks, I wanted to turn the talk into a series of screencasts... but I thought writing it out would actually be a bit easier, and might be more accessible.  (I like screencasts for some things, but I also find it hard to set time aside to watch them.)  And here we are:  as of June 2016, this site has had almost 400,000 unique visitors&mdash;which is approximately 399,990 more than I ever expected!</p>


### PR DESCRIPTION
Fixes #15, in case you'd wish to link to the video hosted on YouTube.