### PR TITLE
feat: vim navigation with j/k keys within page

### DIFF
--- a/source/assets/js/section.js
+++ b/source/assets/js/section.js
@@ -2,16 +2,34 @@ function nav_hotkey(e) {
   var action_for_key = function(e) {
     switch (e.keyCode) {
       case 74:  // 'j'
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
+          return 'next';
+        } else {
+          return 'down';
+        }
       case 78:  // 'n'
         return 'next';
       case 75:  // 'k'
+        if (window.scrollY <= document.body.scrollTop) {
+          return 'prev'
+        } else {
+          return 'up';
+        }
       case 80:  // 'p'
         return 'prev';
     }
   }
+
+  const scrollStep = 50;
   var action = action_for_key(e);
   if (action == 'next' || action == 'prev') {
     var link = $('link[rel="'+action+'"]');
     window.location.href = link[0].href;
+  } else if (action == 'up'){
+    window.scrollTo(document.body.scrollLeft,
+      window.scrollY - scrollStep);
+  } else if (action == 'down'){
+    window.scrollTo(document.body.scrollLeft,
+      window.scrollY + scrollStep);
   }
 }

--- a/source/assets/js/section.js
+++ b/source/assets/js/section.js
@@ -2,19 +2,19 @@ function nav_hotkey(e) {
   var action_for_key = function(e) {
     switch (e.keyCode) {
       case 74:  // 'j'
-        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
-          return 'next';
-        } else {
+        if ((window.innerHeight + window.scrollY) < document.body.scrollHeight) {
           return 'down';
         }
-      case 78:  // 'n'
-        return 'next';
+        return '';
       case 75:  // 'k'
-        if (window.scrollY <= document.body.scrollTop) {
-          return 'prev'
-        } else {
+        if (window.scrollY > document.body.scrollTop) {
           return 'up';
         }
+        return '';
+      case 76:  // 'l'
+      case 78:  // 'n'
+        return 'next';
+      case 72:  // 'h'
       case 80:  // 'p'
         return 'prev';
     }

--- a/source/halp.html.erb
+++ b/source/halp.html.erb
@@ -12,7 +12,7 @@ title: HALP!
 
 <h2>Figure out where you are right now</h2>
 
-<p><strong>I'm going to assume you're on a branch.</strong>  You can confirm this by typing <code class="inline">git status</code> in your repo.  The very first line should say "On branch master" (or "On branch very-important-branch" or whatever the name of the branch you're on is).  <strong>If not, please make a backup of your directory before proceeding and try to get some expert help</strong>!  I can't cover all the possibilities in a document like this, and I'd hate to lead you further astray at this point.</p>
+<p><strong>I'm going to assume you're on a branch.</strong>  You can confirm this by typing <code class="inline">git status</code> in your repo.  The very first line should say "On branch main" (or "On branch very-important-branch" or whatever the name of the branch you're on is).  <strong>If not, please make a backup of your directory before proceeding and try to get some expert help</strong>!  I can't cover all the possibilities in a document like this, and I'd hate to lead you further astray at this point.</p>
 
 <p>If the second line <strong>doesn't</strong> say "nothing to commit (working directory clean)", you have some unsaved changes.  You might be able to save them by using 'git stash', or you might want to copy some files out somewhere else if you're really paranoid.  Or, you just may not care...</p>
 
@@ -24,9 +24,9 @@ title: HALP!
 
 <h2>Finding your lost commit</h2>
 
-<p>Whatever branch you're on, here's the good news:  Git keeps track of every commit that that branch has ever pointed to.  It does this in what's called the 'reflog' <em>(that's short for "reference log")</em> for your branch, which lives in the following plain-text file:  <strong>[repository-root]/.git/logs/refs/heads/[branch-name]</strong>.  The reflog for the <strong>master</strong> branch is in <strong>.git/logs/refs/heads/master</strong>, and the reflog for <strong>very-important-branch</strong> is in <strong>.git/logs/refs/heads/very-important-branch</strong>, and so on.</p>
+<p>Whatever branch you're on, here's the good news:  Git keeps track of every commit that that branch has ever pointed to.  It does this in what's called the 'reflog' <em>(that's short for "reference log")</em> for your branch, which lives in the following plain-text file:  <strong>[repository-root]/.git/logs/refs/heads/[branch-name]</strong>.  The reflog for the <strong>main</strong> branch is in <strong>.git/logs/refs/heads/main</strong>, and the reflog for <strong>very-important-branch</strong> is in <strong>.git/logs/refs/heads/very-important-branch</strong>, and so on.</p>
 
-<p>So. Take a deep breath, go to the root of your repository at the command line, and type this:  <code class="inline">cat .git/logs/refs/heads/master</code></p>
+<p>So. Take a deep breath, go to the root of your repository at the command line, and type this:  <code class="inline">cat .git/logs/refs/heads/main</code></p>
 
 <p>You should see a bunch of lines of the form:</p>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -95,7 +95,7 @@
       <!-- Footer Copyright -->
       <p>
         <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="/assets/images2/cc-license-80x15.png" /></a><br />
-        <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Think Like (a) Git</span> copyright &copy; 2011-2017 <a xmlns:cc="http://creativecommons.org/ns#" href="http://think-like-a-git.net" property="cc:attributionName" rel="cc:attributionURL">Sam Livingston-Gray</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.
+        <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Think Like (a) Git</span> copyright &copy; 2011-2021 <a xmlns:cc="http://creativecommons.org/ns#" href="http://think-like-a-git.net" property="cc:attributionName" rel="cc:attributionURL">Sam Livingston-Gray</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.
       </p>
       <p><br />Original template &copy; 2011 <span>&middot;</span> Vectors Community Theme <span>&middot;</span> All Rights Reserved</p>
       <%= clearer %>

--- a/source/sections/about-this-site.html.erb
+++ b/source/sections/about-this-site.html.erb
@@ -7,6 +7,6 @@ layout: section
 
 <p>Each page has links at the bottom to the previous and next section, so you can read through the site from beginning to end.  If you find that you're already familiar with some of the concepts in a given section, you can use the sidebar navigation to skip to specific pages.</p>
 
-<p><em><strong>Keyboard junkies, you can also navigate between sections using the "N" and "P" keys, for (N)ext and (P)revious.  Vim users may be pleased to know that "J" and "K" also work as they expect.</strong></em></p>
+<p><em><strong>Keyboard junkies, you can also navigate between sections using the "N" and "P" keys, for (N)ext and (P)revious.  Vim users may be pleased to know that "J" and "K" keys work as up and down within page, and "H" and "L" keys move to previous and next page respectively.</strong></em></p>
 
 <p>(I used to have an "EPIC MODE" page that put almost all the content on one big long page, but I haven't been able to figure out how to replicate this using <a href="https://middlemanapp.com/">Middleman</a>.  Feel free to contact me if you know how to do this.)</p>

--- a/source/sections/graphs-and-git/visualizing-your-git-repository.html.erb
+++ b/source/sections/graphs-and-git/visualizing-your-git-repository.html.erb
@@ -43,7 +43,7 @@ layout: section
 
 <code>git log --oneline --abbrev-commit --all --graph --decorate --color</code>
 
-<p>And, in fact, I have a shell alias in my <a href="https://github.com/geeksam/dotfiles/blob/master/bash/aliases">dotfiles repository</a> that does all of this:</p>
+<p>And, in fact, I have a shell alias in my <a href="https://github.com/geeksam/dotfiles/blob/main/bash/aliases">dotfiles repository</a> that does all of this:</p>
 
 <code>alias gg='git log --oneline --abbrev-commit --all --graph --decorate --color'</code>
 

--- a/source/sections/testing-out-merges/the-savepoint-pattern.html.erb
+++ b/source/sections/testing-out-merges/the-savepoint-pattern.html.erb
@@ -23,7 +23,7 @@ layout: section
 
 <h3>The long version</h3>
 
-<p>You're on the <em><strong>master</strong></em> branch and you want the changes from the <em><strong>spiffy_new_feature</strong></em> branch to be incorporated into <em><strong>master.</strong></em>  You're reasonably confident that you'll want to keep the changes, but you want to be able to abort it if, for example, this feature has unintended side effects.</p>
+<p>You're on the <em><strong>main</strong></em> branch and you want the changes from the <em><strong>spiffy_new_feature</strong></em> branch to be incorporated into <em><strong>main.</strong></em>  You're reasonably confident that you'll want to keep the changes, but you want to be able to abort it if, for example, this feature has unintended side effects.</p>
 
 <ol>
   <li>
@@ -31,7 +31,7 @@ layout: section
     <li>
       Whatever visualizer you're using, figure out how it shows you where your current branch is.  Or, at the command line, type <code class="inline">git status</code> and you should see something like this:
       <code>
-        # On branch master <br />
+        # On branch main <br />
         nothing to commit (working directory clean)
       </code>
     </li>
@@ -40,7 +40,7 @@ layout: section
     <strong>Create a new branch to use as a savepoint, but don't switch to it.</strong>
     <ul>
       <li>
-        Type <code class="inline">git branch savepoint</code>.  Now, if you type <code class="inline">git status</code> again, you should still see a message that you're on the <em><strong>master</strong></em> branch.
+        Type <code class="inline">git branch savepoint</code>.  Now, if you type <code class="inline">git status</code> again, you should still see a message that you're on the <em><strong>main</strong></em> branch.
       </li>
     </ul>
   </li>
@@ -60,8 +60,8 @@ layout: section
         For example:
         <ol>
           <li>After a merge, you should see a new commit.</li>
-          <li>The new commit should have a message like "Merge branch 'spiffy_new_feature' into master".</li>
-          <li>Your <em><strong>master</strong></em> branch label should have moved to this new commit, while the <em><strong>spiffy_new_feature</strong></em> branch label should still be in the same place.</li>
+          <li>The new commit should have a message like "Merge branch 'spiffy_new_feature' into main".</li>
+          <li>Your <em><strong>main</strong></em> branch label should have moved to this new commit, while the <em><strong>spiffy_new_feature</strong></em> branch label should still be in the same place.</li>
         </ol>
       </li>
     </ul>

--- a/source/sections/testing-out-merges/the-scout-pattern.html.erb
+++ b/source/sections/testing-out-merges/the-scout-pattern.html.erb
@@ -23,7 +23,7 @@ layout: section
 
 <h3>The long version</h3>
 
-<p>You're on the <em><strong>master</strong></em> branch and you want the changes from the <em><strong>spiffy_new_feature</strong></em> branch to be incorporated into <em><strong>master.</strong></em>  You're not sure if this will be a good idea, so you want to try out the merge, but be able to abort it if things don't go smoothly.</p>
+<p>You're on the <em><strong>main</strong></em> branch and you want the changes from the <em><strong>spiffy_new_feature</strong></em> branch to be incorporated into <em><strong>main.</strong></em>  You're not sure if this will be a good idea, so you want to try out the merge, but be able to abort it if things don't go smoothly.</p>
 
 <ol>
   <li>
@@ -32,7 +32,7 @@ layout: section
       <li>
         Whatever visualizer you're using, figure out how it shows you where your current branch is.  Or, at the command line, type <code class="inline">git status</code> and you should see something like this:
         <code>
-          # On branch master <br />
+          # On branch main <br />
           nothing to commit (working directory clean)
         </code>
       </li>
@@ -63,7 +63,7 @@ layout: section
         <ol>
           <li>After a merge, you should see a new commit.</li>
           <li>The new commit should have a message like "Merge branch 'spiffy_new_feature' into test_merge".</li>
-          <li>Your <em><strong>test_merge</strong></em> branch label should have moved to this new commit, while the <em><strong>master</strong></em> and <em><strong>spiffy_new_feature</strong></em> branch labels should still be in the same place.</li>
+          <li>Your <em><strong>test_merge</strong></em> branch label should have moved to this new commit, while the <em><strong>main</strong></em> and <em><strong>spiffy_new_feature</strong></em> branch labels should still be in the same place.</li>
         </ol>
       </li>
     </ul>
@@ -75,12 +75,12 @@ layout: section
     <strong>Are you happy with the result?</strong>
     <ul>
       <li>
-        <strong>If YES:</strong> Move the <em>master</em> branch forward to where the <em>test_merge</em> branch is with:
-        <code>git checkout master <br />git merge test_merge</code>
+        <strong>If YES:</strong> Move the <em>main</em> branch forward to where the <em>test_merge</em> branch is with:
+        <code>git checkout main <br />git merge test_merge</code>
       </li>
       <li>
         <strong>If NO:</strong> Drop the <em>test_merge</em> branch with:
-        <code>git checkout master <br />git branch -D test_merge</code>
+        <code>git checkout main <br />git branch -D test_merge</code>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
Changed the behaviour of j/k keys to function as up down keys until the
end/start of the page is reached, then subsequent press of j/k should load the next/prev page as in original version.

**As I have never used ruby / your particular build system, I didn't get to testing it.**
Though I tested the functionality separately here: https://jsfiddle.net/vod98e1q/1/
If I'm not mistaken it should work for all major browsers: https://stackoverflow.com/questions/9439725/javascript-how-to-detect-if-browser-window-is-scrolled-to-bottom

Cheers,
Zigmars